### PR TITLE
Use es2015 presets instead of browsers presets

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,12 +5,7 @@
     },
     "test": {
       "presets": [
-        ["env", {
-          "targets": {
-            "chrome": 54,
-            "firefox": 49
-          }
-        }],
+        "es2015",
         "react",
         "stage-1"
       ],
@@ -18,12 +13,7 @@
     },
     "development": {
       "presets": [
-        ["env", {
-          "targets": {
-            "chrome": 54,
-            "firefox": 49
-          }
-        }],
+        "es2015",
         "react-hmre",
         "react",
         "stage-1"

--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
   	<title>Redux Saga Boilerplate</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
     <link rel="icon" href="./src/assets/favicon.ico" />
-    <link rel="stylesheet" href="styles.css" type="text/css" />
+    <link rel="stylesheet" href="/styles.css" type="text/css" />
  </head>
   <body>
   	<div id="app"></div>
-    <script src="bundle.js" type="application/javascript"></script>
+    <script src="/bundle.js" type="application/javascript"></script>
   </body>
 </html>


### PR DESCRIPTION
With es2015 preset we can use fat arrow functions to handle the "this" context. In other hand, with browsers presets is a little buggy, because the reference to this is not the same. For example, when doing setState, the this.state doesn't have the most recent changes.